### PR TITLE
V0.2 - Blender 2.8x 対応（再提出版）

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # quail.py
-old helper functions for mmd_tools v0.6.0
+helper functions for mmd_tools v2.4.0
 
 Blender で MMD モデルを作るお手伝いをするための**やっつけ**スクリプトです。
 品質には期待しないでください。
 
 ## 動作環境
-以下の環境でしか動作確認できていません。
-- Blender 2.79
-- [mmd_tools v0.6.0](https://github.com/powroupi/blender_mmd_tools)
-- Linux（ひょっとしたらWindowsでも動くかもしれません）
+以下の環境で動作することを目指しています。
+- Blender 3.2.2
+- [mmd_tools v2.4.0](https://github.com/UuuNyaa/blender_mmd_tools)
+- Linux（ひょっとしたら Windows にも対応するかもしれません）

--- a/quail.py
+++ b/quail.py
@@ -153,9 +153,9 @@ def check_bone_panel(root_obj: Union[None, bpy.types.Object] = None) -> None:
 			raise RuntimeError("Armature が見つかりませんでした。")
 
 	for frame in root_obj.mmd_root.display_item_frames:
-		for item in frame.items:
-			if item.name in bones:
-				bones[item.name].bone.select = True
+		for data in frame.data:
+			if data.name in bones:
+				bones[data.name].bone.select = True
 
 	print("現在選択されていないボーンは表示パネルに未登録です。")
 

--- a/quail.py
+++ b/quail.py
@@ -540,15 +540,13 @@ def toggle_subsurf(mode: bool, target: Union[None, Sequence[bpy.types.Modifier]]
 					if mod.show_viewport != mode:
 						mod.show_viewport = mode
 						toggled.append(mod)
-
-		print("モディファイア %s を %s にしました。" % (mod_type, mode))
 	else:
 		for mod in target:
 			if mod.show_viewport != mode:
 				mod.show_viewport = mode
 				toggled.append(mod)
 
-		print("モディファイア %s を %s にしました。" % (target, mode))
+	print("モディファイア %s を %s にしました。" % (toggled, mode))
 
 	return toggled
 

--- a/quail.py
+++ b/quail.py
@@ -311,9 +311,9 @@ def select_this_obj_only(obj: bpy.types.Object) -> None:
 	@param obj: (bpy.types.Object) [必須] 選択するオブジェクト
 	"""
 	bpy.ops.object.select_all(action='DESELECT')
-	obj.hide = False
-	obj.select = True
-	bpy.context.active_object = obj
+	obj.hide_viewport = False
+	obj.select_set(True)
+	bpy.context.view_layer.objects.active = obj
 
 	# 強制オブジェクトモード
 	bpy.ops.object.mode_set(mode='OBJECT', toggle=False)
@@ -540,13 +540,15 @@ def toggle_subsurf(mode: bool, target: Union[None, Sequence[bpy.types.Modifier]]
 					if mod.show_viewport != mode:
 						mod.show_viewport = mode
 						toggled.append(mod)
+
+		print("モディファイア %s を %s にしました。" % (mod_type, mode))
 	else:
 		for mod in target:
 			if mod.show_viewport != mode:
 				mod.show_viewport = mode
 				toggled.append(mod)
 
-	print("モディファイア %s を %s にしました。" % (mod_type, mode))
+		print("モディファイア %s を %s にしました。" % (target, mode))
 
 	return toggled
 

--- a/quail.py
+++ b/quail.py
@@ -166,28 +166,25 @@ def set_morph_panel(root_obj: Union[None, bpy.types.Object] = None) -> None:
 
 	@param root_obj: (None | bpy.types.Object) [任意] MMD モデルのルート
 	"""
-	processed_list = []
-
 	if root_obj is None:
 		root_obj = _select_root()
-
-	for i in root_obj.mmd_root.display_item_frames['表情'].items:
-		processed_list.append(i.name)
 
 	for keycolle in bpy.data.shape_keys:
 		# 最初のキーブロックはベース (Basis) なので飛ばします。
 		for shape in keycolle.key_blocks[1:]:
-			if shape.name in processed_list:
-				print(shape.name + " はすでに処理済みです! 二重登録を防止するために中断します。")
+			if shape.name in root_obj.mmd_root.display_item_frames['表情'].data:
 				continue
 
-			temp = root_obj.mmd_root.display_item_frames['表情'].items.add()
+			temp = root_obj.mmd_root.display_item_frames['表情'].data.add()
 			temp.type = 'MORPH'
 			temp.name = shape.name
+
+			if shape.name in root_obj.mmd_root.vertex_morphs:
+				continue
+
 			temp = root_obj.mmd_root.vertex_morphs.add()
 			temp.name = shape.name
 
-			processed_list.append(shape.name)
 			print("%s を登録しました。" % shape.name)
 
 


### PR DESCRIPTION
とりあえず
- [x] 使わなくなった API を削除
- [x] 使えなくなった API を使わないようにした

~~まだデバッグしてません&hearts;~~

動作確認済の関数
- [x] `set_japanese_bone_names()` 廃止予定
- [x] `set_english_bone_names()` 廃止予定
- [x] `show_bone_identifier()`
- [x] `check_invalid_bone_name()`
- [x] `check_bone_panel()`
- [x] `set_morph_panel()`
- [x] `set_english_morph_names()` 廃止予定
- [x] `set_english_rigid_names()` 廃止予定
- [x] `set_english_joint_names()` 廃止予定
- [x] `check_physics_name_duplication_in_mmd()`
- [x] `process_tip_bones_for_mmd()`
- [x] `select_this_obj_only()`
- [x] `apply_shape_as_basis()`
- [x] `toggle_legs_ik()`
- [x] `update_pmx_comment()`
- [x] `switch_layers()`
- [x] `multiply_mass()`
- [x] `toggle_subsurf()`
- [x] `delete_vertex_group()`